### PR TITLE
fix: supported async methods

### DIFF
--- a/override_macro_tests/Cargo.toml
+++ b/override_macro_tests/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2021"
 override_macro = { path = ".." }
 
 [dev-dependencies]
+tokio = { version = "1", features = ["rt", "macros"] }
 trybuild = "1.0"

--- a/override_macro_tests/src/lib.rs
+++ b/override_macro_tests/src/lib.rs
@@ -7,6 +7,7 @@ mod t06_override_for_trait_where;
 mod t07_use_mod_path_for_trait_conflict;
 mod t08_use_mod_alias_for_trait_conflict;
 mod t09_trait_method_conflict;
+mod t10_async_method;
 
 #[test]
 fn compile_error_check() {

--- a/override_macro_tests/src/t10_async_method.rs
+++ b/override_macro_tests/src/t10_async_method.rs
@@ -1,0 +1,52 @@
+use override_macro::{overridable, override_with};
+
+#[overridable]
+trait BaseTrait10 {
+    async fn method0(&self) -> bool;
+    async fn method1(&mut self, b: bool) -> u64;
+}
+
+#[overridable]
+trait DefaultMethodTrait10A {
+    async fn method0(&self) -> bool {
+        true
+    }
+}
+
+#[overridable]
+trait DefaultMethodTrait10B {
+    async fn method1(&mut self, _b: bool) -> u64 {
+        123
+    }
+}
+
+struct Struct10;
+impl DefaultMethodTrait10A for Struct10 {}
+impl DefaultMethodTrait10B for Struct10 {}
+
+#[override_with(DefaultMethodTrait10A, DefaultMethodTrait10B)]
+impl BaseTrait10 for Struct10 {}
+/*
+    async fn method0(&self) -> bool {
+        DefaultMethodTrait10A::method0(self).await
+    }
+    async fn method1(&mut self, _b: bool) -> u64 {
+        DefaultMethodTrait10B::method1(self, _b).await
+    }
+*/
+
+async fn exec(mut i: impl BaseTrait10) {
+    assert!(i.method0().await);
+    assert_eq!(i.method1(true).await, 123);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test() {
+        let s = Struct10 {};
+        exec(s).await;
+    }
+}

--- a/src/logic.rs
+++ b/src/logic.rs
@@ -31,6 +31,7 @@ struct OverridableMethod {
     sig: String,
     call: String,
     has_impl: bool,
+    is_async: bool,
 }
 
 pub fn collect_trait_info(data: &syn_data_acc::OverridableDataAcc) {
@@ -58,12 +59,13 @@ fn register_trait(
 
     let mut method_map = HashMap::<String, OverridableMethod>::new();
 
-    data.for_each_method_registration(|name, sig, call, has_impl, key| {
+    data.for_each_method_registration(|name, sig, call, has_impl, key, is_async| {
         let m = OverridableMethod {
             name,
             sig,
             call,
             has_impl,
+            is_async,
         };
         method_map.insert(key, m);
     });
@@ -134,7 +136,12 @@ pub fn override_trait_methods(data: &mut syn_data_acc::OverrideWithDataAcc) {
                     continue;
                 }
 
-                overriding_methods.push(format!("{} {{ {}::{} }}", m.sig, t_path, m.call));
+                if m.is_async {
+                    overriding_methods
+                        .push(format!("{} {{ {}::{}.await }}", m.sig, t_path, m.call));
+                } else {
+                    overriding_methods.push(format!("{} {{ {}::{} }}", m.sig, t_path, m.call));
+                }
             }
         }
 

--- a/src/syn_data_acc.rs
+++ b/src/syn_data_acc.rs
@@ -127,7 +127,7 @@ impl OverridableDataAcc {
 
     pub fn for_each_method_registration<F>(&self, mut register: F)
     where
-        F: FnMut(String, String, String, bool, String),
+        F: FnMut(String, String, String, bool, String, bool),
     {
         for ti in &self.trait_ast.items {
             match ti {
@@ -138,7 +138,8 @@ impl OverridableDataAcc {
                         let call = make_method_call(&f.sig);
                         let has_impl = f.default.is_some();
                         let search_key = make_method_search_key(&f.sig);
-                        register(name, sig, call, has_impl, search_key);
+                        let is_async = f.sig.asyncness.is_some();
+                        register(name, sig, call, has_impl, search_key, is_async);
                     }
                 }
                 _ => {}


### PR DESCRIPTION
This PR fixes the bug that causes an error when this macro is used on a trait or a struct with async methods.

Closes #8