### PR TITLE
deps: upgrade minimum Rust version to 1.85.1 and toolchain to edition2024

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rustver: ['1.80.1', '1.89.0', '1.94.0']
+        rustver: ['1.85.1', '1.89.0', '1.94.0']
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v5

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "override_macro"
 version = "0.1.1"
 authors = ["Takayuki Sato <sttk.xslet@gmail.com>"]
-edition = "2021"
-rust-version = "1.80.1"
+edition = "2024"
+rust-version = "1.85.1"
 description = "An attribute-like macro for Rust programs to override trait methods with default methods of other traits"
 documentation = "https://docs.rs/override_macro"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -68,31 +68,28 @@ impl Trait0 for Struct0 {
 
 ## Supporting Rust versions
 
-This crate supports Rust 1.80.1 or later.
+This crate supports Rust 1.85.1 or later.
 
 ```sh
 % ./build.sh msrv
-  [Meta]   cargo-msrv 0.18.4
+  [Meta]   cargo-msrv 0.19.3
 
-Compatibility Check #1: Rust 1.74.1
-  [FAIL]   Is incompatible
-
-Compatibility Check #2: Rust 1.83.0
+Compatibility Check #1: Rust 1.91.1
   [OK]     Is compatible
 
-Compatibility Check #3: Rust 1.78.0
-  [FAIL]   Is incompatible
-
-Compatibility Check #4: Rust 1.80.1
+Compatibility Check #2: Rust 1.88.0
   [OK]     Is compatible
 
-Compatibility Check #5: Rust 1.79.0
-  [FAIL]   Is incompatible
+Compatibility Check #3: Rust 1.86.0
+  [OK]     Is compatible
+
+Compatibility Check #4: Rust 1.85.1
+  [OK]     Is compatible
 
 Result:
-   Considered (min … max):   Rust 1.56.1 … Rust 1.91.0
+   Considered (min … max):   Rust 1.85.1 … Rust 1.97.1
    Search method:            bisect
-   MSRV:                     1.80.1
+   MSRV:                     1.85.1
    Target:                   x86_64-apple-darwin
 ```
 


### PR DESCRIPTION
This PR upgrades the toolchain to `edition2024` because a CI test on Rust `1.80.1` and `edition2021` raises the following error, and `edition2024` requires Rust version `1.85.0` or later.
```
Caused by:
  feature `edition2024` is required

  The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.80.1 (376290515 2024-07-16)).
  Consider trying a newer version of Cargo (this may require the nightly release).
  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.
```

This error started occurring because one of the dependent crates was changed to require `edition2024`.
